### PR TITLE
Adds a new endpoint for capturing demand

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/config/OAuth2ResourceServerSecurityConfiguration.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/config/OAuth2ResourceServerSecurityConfiguration.kt
@@ -72,6 +72,8 @@ class OAuth2ResourceServerSecurityConfiguration {
         authorize(HttpMethod.GET, "/cas2/submissions/**", hasAnyRole("CAS2_ASSESSOR", "CAS2_ADMIN"))
         authorize(HttpMethod.POST, "/cas2/submissions/*/status-updates", hasRole("CAS2_ASSESSOR"))
         authorize(HttpMethod.GET, "/cas2/reference-data/**", hasAnyRole("CAS2_ASSESSOR", "POM"))
+        authorize(HttpMethod.POST, "/cas2/demand", hasAnyRole("CAS2_ADMIN", "POM"))
+        authorize(HttpMethod.GET, "/cas2/demand/**", hasAnyRole("CAS2_ADMIN", "POM"))
         authorize(HttpMethod.GET, "/cas2/reports/**", hasRole("CAS2_MI"))
         authorize("/cas2/**", hasAnyAuthority("ROLE_POM", "ROLE_LICENCE_CA"))
         authorize(HttpMethod.GET, "/cas3-api.yml", permitAll)

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/controller/cas2/DemandController.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/controller/cas2/DemandController.kt
@@ -1,0 +1,50 @@
+package uk.gov.justice.digital.hmpps.approvedpremisesapi.controller.cas2
+
+import org.springframework.http.ResponseEntity
+import org.springframework.stereotype.Service
+
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.cas2.DemandCas2Delegate
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.Cas2Demand
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.problem.ForbiddenProblem
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.problem.NotFoundProblem
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.results.CasResult
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.service.NomisUserService
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.service.cas2.DemandService
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.transformer.cas2.DemandTransformer
+
+import java.net.URI
+import java.util.*
+
+@Service("DemandController")
+class DemandController(
+  private val userService: NomisUserService,
+  private val demandService: DemandService,
+  private val demandTransformer: DemandTransformer,
+) : DemandCas2Delegate {
+
+  override fun demandPost(cas2Demand: Cas2Demand): ResponseEntity<Cas2Demand> {
+    val entity = demandService.createCas2Demand(cas2Demand)
+
+    return ResponseEntity
+      .created(URI.create("/cas2/demand/${entity.id}"))
+      .body(demandTransformer.transformJpaToApi(entity))
+  }
+
+  override fun demandIdGet(id: UUID): ResponseEntity<Cas2Demand> {
+    val demand = when (
+      val demandResult = demandService.getDemand(id)
+    ) {
+      is CasResult.NotFound -> null
+      is CasResult.Unauthorised -> throw ForbiddenProblem()
+      is CasResult.Success -> demandResult.value
+      else -> null
+    }
+
+    if (demand != null) {
+      return ResponseEntity.ok(demandTransformer.transformJpaToApi(demand))
+    }
+
+    throw NotFoundProblem(id, "Demand")
+  }
+
+}

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/controller/cas2/ReportsController.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/controller/cas2/ReportsController.kt
@@ -25,6 +25,10 @@ class ReportsController(private val reportService: ReportsService) : ReportsCas2
           outputStream ->
         reportService.createUnsubmittedApplicationsReport(outputStream)
       }
+      Cas2ReportName.bailMinusDemand -> generateXlsxStreamingResponse {
+          outputStream ->
+        reportService.createBailDemandReport(outputStream)
+      }
     }
   }
 }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/jpa/entity/Cas2BailDemandReportRepository.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/jpa/entity/Cas2BailDemandReportRepository.kt
@@ -1,0 +1,25 @@
+package uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity
+
+import org.springframework.data.jpa.repository.JpaRepository
+import org.springframework.data.jpa.repository.Query
+import org.springframework.stereotype.Repository
+import java.util.UUID
+
+@Repository
+interface Cas2BailDemandReportRepository : JpaRepository<DomainEventEntity, UUID> {
+  @Query(
+    """
+      SELECT
+        CAST(identifier AS TEXT) AS identifier
+
+      FROM cas2_demand  
+      ORDER BY decided_at DESC;
+    """,
+    nativeQuery = true,
+  )
+  fun generateBailDemandReport(): List<Cas2BailDemandReportRow>
+}
+
+interface Cas2BailDemandReportRow {
+  fun getIdentifier(): String
+}

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/jpa/entity/Cas2DemandEntity.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/jpa/entity/Cas2DemandEntity.kt
@@ -1,0 +1,28 @@
+package uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity
+
+import jakarta.persistence.Entity
+import jakarta.persistence.Id
+import jakarta.persistence.Table
+import org.springframework.data.jpa.repository.JpaRepository
+import org.springframework.data.jpa.repository.Query
+import org.springframework.stereotype.Repository
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.Cas2Demand
+import java.util.*
+
+@Repository
+interface Cas2DemandRepository : JpaRepository<Cas2DemandEntity, UUID> {
+  @Query(
+    "SELECT d FROM Cas2DemandEntity d WHERE d.id = :id",
+  )
+  override fun findById(id: UUID): Optional<Cas2DemandEntity>
+}
+
+@Entity
+@Table(name = "cas2_demand")
+data class Cas2DemandEntity(
+  @Id
+  val id: UUID,
+  var identifier: String,
+) {
+  override fun toString() = "Cas2DemandEntity: $identifier with id: $id"
+}

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/jpa/entity/Cas2DemandEntity.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/jpa/entity/Cas2DemandEntity.kt
@@ -6,7 +6,7 @@ import jakarta.persistence.Table
 import org.springframework.data.jpa.repository.JpaRepository
 import org.springframework.data.jpa.repository.Query
 import org.springframework.stereotype.Repository
-import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.Cas2Demand
+import java.time.OffsetDateTime
 import java.util.*
 
 @Repository
@@ -22,7 +22,14 @@ interface Cas2DemandRepository : JpaRepository<Cas2DemandEntity, UUID> {
 data class Cas2DemandEntity(
   @Id
   val id: UUID,
-  var identifier: String,
-) {
+  val identifier: String,
+  val locationType: String,
+  val location: String,
+  val primaryReason: String,
+  val secondaryReason: String?,
+  val createdAt: OffsetDateTime,
+  val decidedAt: OffsetDateTime,
+
+  ) {
   override fun toString() = "Cas2DemandEntity: $identifier with id: $id"
 }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/reporting/model/cas2/BailDemandReportRow.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/reporting/model/cas2/BailDemandReportRow.kt
@@ -1,0 +1,6 @@
+package uk.gov.justice.digital.hmpps.approvedpremisesapi.reporting.model.cas2
+
+@Suppress("LongParameterList")
+class BailDemandReportRow(
+  val identifier: String,
+)

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/cas2/DemandService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/cas2/DemandService.kt
@@ -6,6 +6,9 @@ import org.springframework.stereotype.Service
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.Cas2Demand
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.*
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.results.CasResult
+import java.time.Instant
+import java.time.OffsetDateTime
+import java.time.ZoneOffset
 import java.util.UUID
 
 @Service("Cas2DemandService")
@@ -19,6 +22,12 @@ class DemandService(
       Cas2DemandEntity(
         id = UUID.randomUUID(),
         identifier = cas2Demand.identifier,
+        locationType = cas2Demand.locationType,
+        location = cas2Demand.location,
+        primaryReason = cas2Demand.primaryReason,
+        secondaryReason = cas2Demand.secondaryReason,
+        createdAt = convertInstant(cas2Demand.createdAt),
+        decidedAt = convertInstant(cas2Demand.decidedAt),
       ),
     )
 
@@ -27,5 +36,13 @@ class DemandService(
       ?: return CasResult.NotFound()
 
     return CasResult.Success(demandEntity)
+  }
+}
+
+fun convertInstant(instant: Instant?): OffsetDateTime {
+  return instant?.let {
+    OffsetDateTime.ofInstant(instant, ZoneOffset.UTC)
+  } ?: run {
+    OffsetDateTime.now()
   }
 }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/cas2/DemandService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/cas2/DemandService.kt
@@ -1,0 +1,31 @@
+package uk.gov.justice.digital.hmpps.approvedpremisesapi.service.cas2
+
+import jakarta.transaction.Transactional
+import org.springframework.data.repository.findByIdOrNull
+import org.springframework.stereotype.Service
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.Cas2Demand
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.*
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.results.CasResult
+import java.util.UUID
+
+@Service("Cas2DemandService")
+class DemandService(
+  private val demandRepository: Cas2DemandRepository,
+) {
+
+  @Transactional
+  fun createCas2Demand(cas2Demand: Cas2Demand): Cas2DemandEntity =
+    demandRepository.save(
+      Cas2DemandEntity(
+        id = UUID.randomUUID(),
+        identifier = cas2Demand.identifier,
+      ),
+    )
+
+  fun getDemand(id: UUID): CasResult<Cas2DemandEntity> {
+    val demandEntity = demandRepository.findByIdOrNull(id)
+      ?: return CasResult.NotFound()
+
+    return CasResult.Success(demandEntity)
+  }
+}

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/cas2/ReportsService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/cas2/ReportsService.kt
@@ -5,11 +5,13 @@ import org.jetbrains.kotlinx.dataframe.api.toDataFrame
 import org.jetbrains.kotlinx.dataframe.io.writeExcel
 import org.springframework.stereotype.Service
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.Cas2ApplicationStatusUpdatesReportRepository
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.Cas2BailDemandReportRepository
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.Cas2SubmittedApplicationReportRepository
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.Cas2UnsubmittedApplicationsReportRepository
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.reporting.model.cas2.ApplicationStatusUpdatesReportRow
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.reporting.model.cas2.SubmittedApplicationReportRow
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.reporting.model.cas2.UnsubmittedApplicationsReportRow
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.reporting.model.cas2.BailDemandReportRow
 import java.io.OutputStream
 
 @Service
@@ -17,6 +19,7 @@ class ReportsService(
   private val submittedApplicationReportRepository: Cas2SubmittedApplicationReportRepository,
   private val applicationStatusUpdatesReportRepository: Cas2ApplicationStatusUpdatesReportRepository,
   private val unsubmittedApplicationsReportRepository: Cas2UnsubmittedApplicationsReportRepository,
+  private val bailDemandReportRepository: Cas2BailDemandReportRepository,
 ) {
 
   fun createSubmittedApplicationsReport(outputStream: OutputStream) {
@@ -72,6 +75,20 @@ class ReportsService(
         personNoms = row.getPersonNoms(),
         startedBy = row.getStartedBy(),
         startedAt = row.getStartedAt(),
+      )
+    }
+
+    reportData.toDataFrame()
+      .writeExcel(
+        outputStream = outputStream,
+        factory = WorkbookFactory.create(true),
+      )
+  }
+
+  fun createBailDemandReport(outputStream: OutputStream) {
+    val reportData = bailDemandReportRepository.generateBailDemandReport().map { row ->
+      BailDemandReportRow(
+        identifier = row.getIdentifier(),
       )
     }
 

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/transformer/cas2/DemandTransformer.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/transformer/cas2/DemandTransformer.kt
@@ -11,7 +11,12 @@ class DemandTransformer(
   fun transformJpaToApi(jpa: Cas2DemandEntity): Cas2Demand {
     return Cas2Demand(
       id = jpa.id,
-      identifier = jpa.identifier
-    )
-  }
+      identifier = jpa.identifier,
+      locationType = jpa.locationType,
+      location = jpa.location,
+      primaryReason = jpa.primaryReason,
+      secondaryReason = jpa.secondaryReason,
+      createdAt = jpa.createdAt.toInstant(),
+      decidedAt = jpa.createdAt.toInstant(),
+    ) }
 }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/transformer/cas2/DemandTransformer.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/transformer/cas2/DemandTransformer.kt
@@ -1,0 +1,17 @@
+package uk.gov.justice.digital.hmpps.approvedpremisesapi.transformer.cas2
+
+import org.springframework.stereotype.Component
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.Cas2Demand
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.Cas2DemandEntity
+
+@Component("Cas2DemandTransformer")
+class DemandTransformer(
+) {
+
+  fun transformJpaToApi(jpa: Cas2DemandEntity): Cas2Demand {
+    return Cas2Demand(
+      id = jpa.id,
+      identifier = jpa.identifier
+    )
+  }
+}

--- a/src/main/resources/db/migration/all/2024122211495000__add_demands_table.sql
+++ b/src/main/resources/db/migration/all/2024122211495000__add_demands_table.sql
@@ -1,0 +1,5 @@
+CREATE TABLE cas2_demand (
+    id UUID NOT NULL,
+    identifier TEXT NOT NULL,
+    PRIMARY KEY (id)
+);

--- a/src/main/resources/db/migration/all/2024122211495000__add_demands_table.sql
+++ b/src/main/resources/db/migration/all/2024122211495000__add_demands_table.sql
@@ -1,5 +1,16 @@
+
 CREATE TABLE cas2_demand (
     id UUID NOT NULL,
+    created_at TIMESTAMP WITH TIME ZONE NOT NULL DEFAULT NOW(),
+    decided_at TIMESTAMP WITH TIME ZONE NOT NULL DEFAULT NOW(),
+
     identifier TEXT NOT NULL,
+
+    location_type TEXT NOT NULL,
+    location TEXT NOT NULL,
+
+    primary_reason TEXT NOT NULL,
+    secondary_reason TEXT,
+
     PRIMARY KEY (id)
 );

--- a/src/main/resources/static/_shared.yml
+++ b/src/main/resources/static/_shared.yml
@@ -2020,6 +2020,18 @@ components:
         - id
         - name
         - label
+    Cas2Demand:
+      type: object
+      properties:
+        id:
+          type: string
+          format: uuid
+        identifier:
+          type: string
+          example: 'hashed-string'
+          description: 'The unique identifier for the defendant'
+      required:
+        - identifier
     Cas2AssessmentStatusUpdate:
       type: object
       properties:

--- a/src/main/resources/static/_shared.yml
+++ b/src/main/resources/static/_shared.yml
@@ -2030,8 +2030,27 @@ components:
           type: string
           example: 'hashed-string'
           description: 'The unique identifier for the defendant'
+        createdAt:
+          type: string
+          format: date-time
+        decidedAt:
+          type: string
+          format: date-time
+        locationType:
+          type: string
+          example: 'court'
+        location:
+          type: string
+        primaryReason:
+          type: string
+          example: ""
+        secondaryReason:
+          type: string
       required:
         - identifier
+        - locationType
+        - location
+        - primaryReason
     Cas2AssessmentStatusUpdate:
       type: object
       properties:

--- a/src/main/resources/static/_shared.yml
+++ b/src/main/resources/static/_shared.yml
@@ -4936,6 +4936,7 @@ components:
         - submitted-applications
         - application-status-updates
         - unsubmitted-applications
+        - bail-demand
     NamedId:
       type: object
       description: A generic stub for an object with a name and an ID.

--- a/src/main/resources/static/cas2-api.yml
+++ b/src/main/resources/static/cas2-api.yml
@@ -3,12 +3,69 @@ info:
   title: 'Community Accommodation Services: Tier 2 (CAS2)'
   version: 1.0.0
 servers:
-  - url: /cas2
+- url: /cas2
 paths:
+  /demand:
+    post:
+      tags:
+        - Operations on CAS2 demand
+      summary: Creates a new demand record
+      requestBody:
+        description: Details of the demand record
+        content:
+          'application/json':
+            schema:
+              $ref: '_shared.yml#/components/schemas/Cas2Demand'
+        required: true
+      responses:
+        201:
+          description: successful operation
+          content:
+            'application/json':
+              schema:
+                $ref: '_shared.yml#/components/schemas/Cas2Demand'
+        400:
+          description: demand has already been submitted
+          content:
+            'application/problem+json':
+              schema:
+                $ref: '_shared.yml#/components/schemas/ValidationError'
+        401:
+          $ref: '_shared.yml#/components/responses/401Response'
+        403:
+          $ref: '_shared.yml#/components/responses/403Response'
+        500:
+          $ref: '_shared.yml#/components/responses/500Response'
+  /demand/{id}:
+    get:
+      tags:
+        - Operations on CAS2 demand
+      summary: Gets a single CAS2 demand by its ID
+      parameters:
+        - name: id
+          in: path
+          description: ID of the demand
+          required: true
+          schema:
+            type: string
+            format: uuid
+      responses:
+        200:
+          description: successful operation
+          content:
+            'application/json':
+              schema:
+                $ref: '_shared.yml#/components/schemas/Cas2Demand'
+        401:
+          $ref: '_shared.yml#/components/responses/401Response'
+        403:
+          $ref: '_shared.yml#/components/responses/403Response'
+        500:
+          $ref: '_shared.yml#/components/responses/500Response'
   /applications:
     post:
       tags:
-        - Operations on CAS2 applications
+      - Operations on CAS2 applications
       summary: Creates a CAS2 application
       requestBody:
         description: Information to create a blank application with
@@ -45,24 +102,24 @@ paths:
       x-codegen-request-body-name: body
     get:
       tags:
-        - Operations on CAS2 applications
+      - Operations on CAS2 applications
       summary: List summaries of all CAS2 applications authorised for the logged in user
       parameters:
-        - name: isSubmitted
-          in: query
-          description: Returns submitted applications if true, un submitted applications if false, and all applications if absent
-          schema:
-            type: boolean
-        - name: page
-          in: query
-          description: Page number of results to return.  If blank, returns all results
-          schema:
-            type: integer
-        - name: prisonCode
-          in: query
-          description: Prison code of applications to return.  If blank, returns all results.
-          schema:
-            type: string
+      - name: isSubmitted
+        in: query
+        description: Returns submitted applications if true, un submitted applications if false, and all applications if absent
+        schema:
+          type: boolean
+      - name: page
+        in: query
+        description: Page number of results to return.  If blank, returns all results
+        schema:
+          type: integer
+      - name: prisonCode
+        in: query
+        description: Prison code of applications to return.  If blank, returns all results.
+        schema:
+          type: string
       responses:
         200:
           description: successful operation
@@ -91,16 +148,16 @@ paths:
   /applications/{applicationId}:
     put:
       tags:
-        - Operations on CAS2 applications
+      - Operations on CAS2 applications
       summary: Updates a CAS2 application
       parameters:
-        - name: applicationId
-          in: path
-          description: ID of the application
-          required: true
-          schema:
-            type: string
-            format: uuid
+      - name: applicationId
+        in: path
+        description: ID of the application
+        required: true
+        schema:
+          type: string
+          format: uuid
       requestBody:
         description: Information to update the application with
         content:
@@ -130,16 +187,16 @@ paths:
       x-codegen-request-body-name: body
     get:
       tags:
-        - Operations on CAS2 applications
+      - Operations on CAS2 applications
       summary: Gets a single CAS2 application by its ID
       parameters:
-        - name: applicationId
-          in: path
-          description: ID of the application
-          required: true
-          schema:
-            type: string
-            format: uuid
+      - name: applicationId
+        in: path
+        description: ID of the application
+        required: true
+        schema:
+          type: string
+          format: uuid
       responses:
         200:
           description: successful operation
@@ -156,16 +213,16 @@ paths:
   /applications/{applicationId}/abandon:
     put:
       tags:
-        - Operations on CAS2 applications
+      - Operations on CAS2 applications
       summary: Abandons an in progress CAS2 application
       parameters:
-        - name: applicationId
-          in: path
-          description: ID of the application
-          required: true
-          schema:
-            type: string
-            format: uuid
+      - name: applicationId
+        in: path
+        description: ID of the application
+        required: true
+        schema:
+          type: string
+          format: uuid
       responses:
         200:
           description: successful operation
@@ -182,16 +239,16 @@ paths:
   /assessments/{assessmentId}:
     put:
       tags:
-        - Operations on submitted CAS2 applications (Assessors)
+      - Operations on submitted CAS2 applications (Assessors)
       summary: Updates a single CAS2 assessment by its ID
       parameters:
-        - name: assessmentId
-          in: path
-          description: ID of the assessment
-          required: true
-          schema:
-            type: string
-            format: uuid
+      - name: assessmentId
+        in: path
+        description: ID of the assessment
+        required: true
+        schema:
+          type: string
+          format: uuid
       requestBody:
         description: Information to update the assessment with
         content:
@@ -220,16 +277,16 @@ paths:
           $ref: '_shared.yml#/components/responses/500Response'
     get:
       tags:
-        - Operations on submitted CAS2 applications (Assessors)
+      - Operations on submitted CAS2 applications (Assessors)
       summary: Gets a single CAS2 assessment by its ID
       parameters:
-        - name: assessmentId
-          in: path
-          description: ID of the assessment
-          required: true
-          schema:
-            type: string
-            format: uuid
+      - name: assessmentId
+        in: path
+        description: ID of the assessment
+        required: true
+        schema:
+          type: string
+          format: uuid
       responses:
         200:
           description: successful operation
@@ -252,16 +309,16 @@ paths:
   /assessments/{assessmentId}/status-updates:
     post:
       tags:
-        - Operations on submitted CAS2 applications (Assessors)
+      - Operations on submitted CAS2 applications (Assessors)
       summary: Creates a status update on an assessment
       parameters:
-        - name: assessmentId
-          in: path
-          description: ID of the assessment whose status is to be updated
-          required: true
-          schema:
-            type: string
-            format: uuid
+      - name: assessmentId
+        in: path
+        description: ID of the assessment whose status is to be updated
+        required: true
+        schema:
+          type: string
+          format: uuid
       requestBody:
         description: Information on the new status to be applied
         content:
@@ -287,16 +344,16 @@ paths:
   /assessments/{assessmentId}/notes:
     post:
       tags:
-        - Operations on CAS2 assessments
+      - Operations on CAS2 assessments
       summary: Add a note to an assessment
       parameters:
-        - name: assessmentId
-          in: path
-          description: ID of the assessment
-          required: true
-          schema:
-            type: string
-            format: uuid
+      - name: assessmentId
+        in: path
+        description: ID of the assessment
+        required: true
+        schema:
+          type: string
+          format: uuid
       requestBody:
         description: the note to add
         content:
@@ -327,14 +384,14 @@ paths:
   /submissions:
     get:
       tags:
-        - Operations on submitted CAS2 applications (Assessors)
+      - Operations on submitted CAS2 applications (Assessors)
       summary: List summaries of all submitted CAS2 applications
       parameters:
-        - name: page
-          in: query
-          description: Page number of results to return. If blank, returns all results
-          schema:
-            type: integer
+      - name: page
+        in: query
+        description: Page number of results to return. If blank, returns all results
+        schema:
+          type: integer
       responses:
         200:
           description: successful operation
@@ -361,7 +418,7 @@ paths:
           $ref: '_shared.yml#/components/responses/500Response'
     post:
       tags:
-        - Operations on CAS2 applications
+      - Operations on CAS2 applications
       summary: Submits a CAS2 Application (creates a SubmittedApplication)
       requestBody:
         description: Information needed to submit an application
@@ -388,16 +445,16 @@ paths:
   /submissions/{applicationId}:
     get:
       tags:
-        - Operations on submitted CAS2 applications (Assessors)
+      - Operations on submitted CAS2 applications (Assessors)
       summary: Gets a single submitted CAS2 application by its ID
       parameters:
-        - name: applicationId
-          in: path
-          description: ID of the application
-          required: true
-          schema:
-            type: string
-            format: uuid
+      - name: applicationId
+        in: path
+        description: ID of the application
+        required: true
+        schema:
+          type: string
+          format: uuid
       responses:
         200:
           description: successful operation
@@ -414,15 +471,15 @@ paths:
   /people/search:
     get:
       tags:
-        - People operations
+      - People operations
       summary: Searches for a Person by their Prison Number (NOMIS ID)
       parameters:
-        - name: nomsNumber
-          in: query
-          description: Prison Number to search for
-          required: true
-          schema:
-            type: string
+      - name: nomsNumber
+        in: query
+        description: Prison Number to search for
+        required: true
+        schema:
+          type: string
       responses:
         200:
           description: successful operation
@@ -451,15 +508,15 @@ paths:
   /people/{crn}/oasys/risk-to-self:
     get:
       tags:
-        - People operations
+      - People operations
       summary: Returns the Risk To Individual (known as Risk to Self on frontend) section of an OASys.
       parameters:
-        - name: crn
-          in: path
-          description: CRN of the Person to fetch latest OASys
-          required: true
-          schema:
-            type: string
+      - name: crn
+        in: path
+        description: CRN of the Person to fetch latest OASys
+        required: true
+        schema:
+          type: string
       responses:
         200:
           description: successful operation
@@ -482,15 +539,15 @@ paths:
   /people/{crn}/oasys/rosh:
     get:
       tags:
-        - People operations
+      - People operations
       summary: Returns the Risk of Serious Harm section of an OASys.
       parameters:
-        - name: crn
-          in: path
-          description: CRN of the Person to fetch latest OASys
-          required: true
-          schema:
-            type: string
+      - name: crn
+        in: path
+        description: CRN of the Person to fetch latest OASys
+        required: true
+        schema:
+          type: string
       responses:
         200:
           description: successful operation
@@ -513,15 +570,15 @@ paths:
   /people/{crn}/risks:
     get:
       tags:
-        - People operations
+      - People operations
       summary: Returns the risks for a Person
       parameters:
-        - name: crn
-          in: path
-          description: CRN of the Person to fetch risks for
-          required: true
-          schema:
-            type: string
+      - name: crn
+        in: path
+        description: CRN of the Person to fetch risks for
+        required: true
+        schema:
+          type: string
       responses:
         200:
           description: successful operation
@@ -550,7 +607,7 @@ paths:
   /reference-data/application-status:
     get:
       tags:
-        - Reference Data
+      - Reference Data
       summary: Lists all application status update choices
       responses:
         200:
@@ -570,15 +627,15 @@ paths:
   /reports/{reportName}:
     get:
       tags:
-        - Reports
+      - Reports
       summary: Returns a 'report' spreadsheet of metrics
       parameters:
-        - name: reportName
-          in: path
-          description: name of the report to download
-          required: true
-          schema:
-            $ref: '_shared.yml#/components/schemas/Cas2ReportName'
+      - name: reportName
+        in: path
+        description: name of the report to download
+        required: true
+        schema:
+          $ref: '_shared.yml#/components/schemas/Cas2ReportName'
       responses:
         200:
           description: successful operation

--- a/src/main/resources/static/codegen/built-api-spec.yml
+++ b/src/main/resources/static/codegen/built-api-spec.yml
@@ -6313,8 +6313,27 @@ components:
           type: string
           example: 'hashed-string'
           description: 'The unique identifier for the defendant'
+        createdAt:
+          type: string
+          format: date-time
+        decidedAt:
+          type: string
+          format: date-time
+        locationType:
+          type: string
+          example: 'court'
+        location:
+          type: string
+        primaryReason:
+          type: string
+          example: ""
+        secondaryReason:
+          type: string
       required:
         - identifier
+        - locationType
+        - location
+        - primaryReason
     Cas2AssessmentStatusUpdate:
       type: object
       properties:

--- a/src/main/resources/static/codegen/built-api-spec.yml
+++ b/src/main/resources/static/codegen/built-api-spec.yml
@@ -6303,6 +6303,18 @@ components:
         - id
         - name
         - label
+    Cas2Demand:
+      type: object
+      properties:
+        id:
+          type: string
+          format: uuid
+        identifier:
+          type: string
+          example: 'hashed-string'
+          description: 'The unique identifier for the defendant'
+      required:
+        - identifier
     Cas2AssessmentStatusUpdate:
       type: object
       properties:

--- a/src/main/resources/static/codegen/built-api-spec.yml
+++ b/src/main/resources/static/codegen/built-api-spec.yml
@@ -9219,6 +9219,7 @@ components:
         - submitted-applications
         - application-status-updates
         - unsubmitted-applications
+        - bail-demand
     NamedId:
       type: object
       description: A generic stub for an object with a name and an ID.

--- a/src/main/resources/static/codegen/built-cas1-api-spec.yml
+++ b/src/main/resources/static/codegen/built-cas1-api-spec.yml
@@ -6117,6 +6117,7 @@ components:
         - submitted-applications
         - application-status-updates
         - unsubmitted-applications
+        - bail-demand
     NamedId:
       type: object
       description: A generic stub for an object with a name and an ID.

--- a/src/main/resources/static/codegen/built-cas1-api-spec.yml
+++ b/src/main/resources/static/codegen/built-cas1-api-spec.yml
@@ -3201,6 +3201,18 @@ components:
         - id
         - name
         - label
+    Cas2Demand:
+      type: object
+      properties:
+        id:
+          type: string
+          format: uuid
+        identifier:
+          type: string
+          example: 'hashed-string'
+          description: 'The unique identifier for the defendant'
+      required:
+        - identifier
     Cas2AssessmentStatusUpdate:
       type: object
       properties:

--- a/src/main/resources/static/codegen/built-cas1-api-spec.yml
+++ b/src/main/resources/static/codegen/built-cas1-api-spec.yml
@@ -3211,8 +3211,27 @@ components:
           type: string
           example: 'hashed-string'
           description: 'The unique identifier for the defendant'
+        createdAt:
+          type: string
+          format: date-time
+        decidedAt:
+          type: string
+          format: date-time
+        locationType:
+          type: string
+          example: 'court'
+        location:
+          type: string
+        primaryReason:
+          type: string
+          example: ""
+        secondaryReason:
+          type: string
       required:
         - identifier
+        - locationType
+        - location
+        - primaryReason
     Cas2AssessmentStatusUpdate:
       type: object
       properties:

--- a/src/main/resources/static/codegen/built-cas2-api-spec.yml
+++ b/src/main/resources/static/codegen/built-cas2-api-spec.yml
@@ -5,12 +5,69 @@ info:
   title: 'Community Accommodation Services: Tier 2 (CAS2)'
   version: 1.0.0
 servers:
-  - url: /cas2
+- url: /cas2
 paths:
+  /demand:
+    post:
+      tags:
+        - Operations on CAS2 demand
+      summary: Creates a new demand record
+      requestBody:
+        description: Details of the demand record
+        content:
+          'application/json':
+            schema:
+              $ref: '#/components/schemas/Cas2Demand'
+        required: true
+      responses:
+        201:
+          description: successful operation
+          content:
+            'application/json':
+              schema:
+                $ref: '#/components/schemas/Cas2Demand'
+        400:
+          description: demand has already been submitted
+          content:
+            'application/problem+json':
+              schema:
+                $ref: '#/components/schemas/ValidationError'
+        401:
+          $ref: '#/components/responses/401Response'
+        403:
+          $ref: '#/components/responses/403Response'
+        500:
+          $ref: '#/components/responses/500Response'
+  /demand/{id}:
+    get:
+      tags:
+        - Operations on CAS2 demand
+      summary: Gets a single CAS2 demand by its ID
+      parameters:
+        - name: id
+          in: path
+          description: ID of the demand
+          required: true
+          schema:
+            type: string
+            format: uuid
+      responses:
+        200:
+          description: successful operation
+          content:
+            'application/json':
+              schema:
+                $ref: '#/components/schemas/Cas2Demand'
+        401:
+          $ref: '#/components/responses/401Response'
+        403:
+          $ref: '#/components/responses/403Response'
+        500:
+          $ref: '#/components/responses/500Response'
   /applications:
     post:
       tags:
-        - Operations on CAS2 applications
+      - Operations on CAS2 applications
       summary: Creates a CAS2 application
       requestBody:
         description: Information to create a blank application with
@@ -47,24 +104,24 @@ paths:
       x-codegen-request-body-name: body
     get:
       tags:
-        - Operations on CAS2 applications
+      - Operations on CAS2 applications
       summary: List summaries of all CAS2 applications authorised for the logged in user
       parameters:
-        - name: isSubmitted
-          in: query
-          description: Returns submitted applications if true, un submitted applications if false, and all applications if absent
-          schema:
-            type: boolean
-        - name: page
-          in: query
-          description: Page number of results to return.  If blank, returns all results
-          schema:
-            type: integer
-        - name: prisonCode
-          in: query
-          description: Prison code of applications to return.  If blank, returns all results.
-          schema:
-            type: string
+      - name: isSubmitted
+        in: query
+        description: Returns submitted applications if true, un submitted applications if false, and all applications if absent
+        schema:
+          type: boolean
+      - name: page
+        in: query
+        description: Page number of results to return.  If blank, returns all results
+        schema:
+          type: integer
+      - name: prisonCode
+        in: query
+        description: Prison code of applications to return.  If blank, returns all results.
+        schema:
+          type: string
       responses:
         200:
           description: successful operation
@@ -93,16 +150,16 @@ paths:
   /applications/{applicationId}:
     put:
       tags:
-        - Operations on CAS2 applications
+      - Operations on CAS2 applications
       summary: Updates a CAS2 application
       parameters:
-        - name: applicationId
-          in: path
-          description: ID of the application
-          required: true
-          schema:
-            type: string
-            format: uuid
+      - name: applicationId
+        in: path
+        description: ID of the application
+        required: true
+        schema:
+          type: string
+          format: uuid
       requestBody:
         description: Information to update the application with
         content:
@@ -132,16 +189,16 @@ paths:
       x-codegen-request-body-name: body
     get:
       tags:
-        - Operations on CAS2 applications
+      - Operations on CAS2 applications
       summary: Gets a single CAS2 application by its ID
       parameters:
-        - name: applicationId
-          in: path
-          description: ID of the application
-          required: true
-          schema:
-            type: string
-            format: uuid
+      - name: applicationId
+        in: path
+        description: ID of the application
+        required: true
+        schema:
+          type: string
+          format: uuid
       responses:
         200:
           description: successful operation
@@ -158,16 +215,16 @@ paths:
   /applications/{applicationId}/abandon:
     put:
       tags:
-        - Operations on CAS2 applications
+      - Operations on CAS2 applications
       summary: Abandons an in progress CAS2 application
       parameters:
-        - name: applicationId
-          in: path
-          description: ID of the application
-          required: true
-          schema:
-            type: string
-            format: uuid
+      - name: applicationId
+        in: path
+        description: ID of the application
+        required: true
+        schema:
+          type: string
+          format: uuid
       responses:
         200:
           description: successful operation
@@ -184,16 +241,16 @@ paths:
   /assessments/{assessmentId}:
     put:
       tags:
-        - Operations on submitted CAS2 applications (Assessors)
+      - Operations on submitted CAS2 applications (Assessors)
       summary: Updates a single CAS2 assessment by its ID
       parameters:
-        - name: assessmentId
-          in: path
-          description: ID of the assessment
-          required: true
-          schema:
-            type: string
-            format: uuid
+      - name: assessmentId
+        in: path
+        description: ID of the assessment
+        required: true
+        schema:
+          type: string
+          format: uuid
       requestBody:
         description: Information to update the assessment with
         content:
@@ -222,16 +279,16 @@ paths:
           $ref: '#/components/responses/500Response'
     get:
       tags:
-        - Operations on submitted CAS2 applications (Assessors)
+      - Operations on submitted CAS2 applications (Assessors)
       summary: Gets a single CAS2 assessment by its ID
       parameters:
-        - name: assessmentId
-          in: path
-          description: ID of the assessment
-          required: true
-          schema:
-            type: string
-            format: uuid
+      - name: assessmentId
+        in: path
+        description: ID of the assessment
+        required: true
+        schema:
+          type: string
+          format: uuid
       responses:
         200:
           description: successful operation
@@ -254,16 +311,16 @@ paths:
   /assessments/{assessmentId}/status-updates:
     post:
       tags:
-        - Operations on submitted CAS2 applications (Assessors)
+      - Operations on submitted CAS2 applications (Assessors)
       summary: Creates a status update on an assessment
       parameters:
-        - name: assessmentId
-          in: path
-          description: ID of the assessment whose status is to be updated
-          required: true
-          schema:
-            type: string
-            format: uuid
+      - name: assessmentId
+        in: path
+        description: ID of the assessment whose status is to be updated
+        required: true
+        schema:
+          type: string
+          format: uuid
       requestBody:
         description: Information on the new status to be applied
         content:
@@ -289,16 +346,16 @@ paths:
   /assessments/{assessmentId}/notes:
     post:
       tags:
-        - Operations on CAS2 assessments
+      - Operations on CAS2 assessments
       summary: Add a note to an assessment
       parameters:
-        - name: assessmentId
-          in: path
-          description: ID of the assessment
-          required: true
-          schema:
-            type: string
-            format: uuid
+      - name: assessmentId
+        in: path
+        description: ID of the assessment
+        required: true
+        schema:
+          type: string
+          format: uuid
       requestBody:
         description: the note to add
         content:
@@ -329,14 +386,14 @@ paths:
   /submissions:
     get:
       tags:
-        - Operations on submitted CAS2 applications (Assessors)
+      - Operations on submitted CAS2 applications (Assessors)
       summary: List summaries of all submitted CAS2 applications
       parameters:
-        - name: page
-          in: query
-          description: Page number of results to return. If blank, returns all results
-          schema:
-            type: integer
+      - name: page
+        in: query
+        description: Page number of results to return. If blank, returns all results
+        schema:
+          type: integer
       responses:
         200:
           description: successful operation
@@ -363,7 +420,7 @@ paths:
           $ref: '#/components/responses/500Response'
     post:
       tags:
-        - Operations on CAS2 applications
+      - Operations on CAS2 applications
       summary: Submits a CAS2 Application (creates a SubmittedApplication)
       requestBody:
         description: Information needed to submit an application
@@ -390,16 +447,16 @@ paths:
   /submissions/{applicationId}:
     get:
       tags:
-        - Operations on submitted CAS2 applications (Assessors)
+      - Operations on submitted CAS2 applications (Assessors)
       summary: Gets a single submitted CAS2 application by its ID
       parameters:
-        - name: applicationId
-          in: path
-          description: ID of the application
-          required: true
-          schema:
-            type: string
-            format: uuid
+      - name: applicationId
+        in: path
+        description: ID of the application
+        required: true
+        schema:
+          type: string
+          format: uuid
       responses:
         200:
           description: successful operation
@@ -416,15 +473,15 @@ paths:
   /people/search:
     get:
       tags:
-        - People operations
+      - People operations
       summary: Searches for a Person by their Prison Number (NOMIS ID)
       parameters:
-        - name: nomsNumber
-          in: query
-          description: Prison Number to search for
-          required: true
-          schema:
-            type: string
+      - name: nomsNumber
+        in: query
+        description: Prison Number to search for
+        required: true
+        schema:
+          type: string
       responses:
         200:
           description: successful operation
@@ -453,15 +510,15 @@ paths:
   /people/{crn}/oasys/risk-to-self:
     get:
       tags:
-        - People operations
+      - People operations
       summary: Returns the Risk To Individual (known as Risk to Self on frontend) section of an OASys.
       parameters:
-        - name: crn
-          in: path
-          description: CRN of the Person to fetch latest OASys
-          required: true
-          schema:
-            type: string
+      - name: crn
+        in: path
+        description: CRN of the Person to fetch latest OASys
+        required: true
+        schema:
+          type: string
       responses:
         200:
           description: successful operation
@@ -484,15 +541,15 @@ paths:
   /people/{crn}/oasys/rosh:
     get:
       tags:
-        - People operations
+      - People operations
       summary: Returns the Risk of Serious Harm section of an OASys.
       parameters:
-        - name: crn
-          in: path
-          description: CRN of the Person to fetch latest OASys
-          required: true
-          schema:
-            type: string
+      - name: crn
+        in: path
+        description: CRN of the Person to fetch latest OASys
+        required: true
+        schema:
+          type: string
       responses:
         200:
           description: successful operation
@@ -515,15 +572,15 @@ paths:
   /people/{crn}/risks:
     get:
       tags:
-        - People operations
+      - People operations
       summary: Returns the risks for a Person
       parameters:
-        - name: crn
-          in: path
-          description: CRN of the Person to fetch risks for
-          required: true
-          schema:
-            type: string
+      - name: crn
+        in: path
+        description: CRN of the Person to fetch risks for
+        required: true
+        schema:
+          type: string
       responses:
         200:
           description: successful operation
@@ -552,7 +609,7 @@ paths:
   /reference-data/application-status:
     get:
       tags:
-        - Reference Data
+      - Reference Data
       summary: Lists all application status update choices
       responses:
         200:
@@ -572,15 +629,15 @@ paths:
   /reports/{reportName}:
     get:
       tags:
-        - Reports
+      - Reports
       summary: Returns a 'report' spreadsheet of metrics
       parameters:
-        - name: reportName
-          in: path
-          description: name of the report to download
-          required: true
-          schema:
-            $ref: '#/components/schemas/Cas2ReportName'
+      - name: reportName
+        in: path
+        description: name of the report to download
+        required: true
+        schema:
+          $ref: '#/components/schemas/Cas2ReportName'
       responses:
         200:
           description: successful operation
@@ -2611,6 +2668,18 @@ components:
         - id
         - name
         - label
+    Cas2Demand:
+      type: object
+      properties:
+        id:
+          type: string
+          format: uuid
+        identifier:
+          type: string
+          example: 'hashed-string'
+          description: 'The unique identifier for the defendant'
+      required:
+        - identifier
     Cas2AssessmentStatusUpdate:
       type: object
       properties:

--- a/src/main/resources/static/codegen/built-cas2-api-spec.yml
+++ b/src/main/resources/static/codegen/built-cas2-api-spec.yml
@@ -2678,8 +2678,27 @@ components:
           type: string
           example: 'hashed-string'
           description: 'The unique identifier for the defendant'
+        createdAt:
+          type: string
+          format: date-time
+        decidedAt:
+          type: string
+          format: date-time
+        locationType:
+          type: string
+          example: 'court'
+        location:
+          type: string
+        primaryReason:
+          type: string
+          example: ""
+        secondaryReason:
+          type: string
       required:
         - identifier
+        - locationType
+        - location
+        - primaryReason
     Cas2AssessmentStatusUpdate:
       type: object
       properties:

--- a/src/main/resources/static/codegen/built-cas2-api-spec.yml
+++ b/src/main/resources/static/codegen/built-cas2-api-spec.yml
@@ -5584,6 +5584,7 @@ components:
         - submitted-applications
         - application-status-updates
         - unsubmitted-applications
+        - bail-demand
     NamedId:
       type: object
       description: A generic stub for an object with a name and an ID.

--- a/src/main/resources/static/codegen/built-cas3-api-spec.yml
+++ b/src/main/resources/static/codegen/built-cas3-api-spec.yml
@@ -2119,6 +2119,18 @@ components:
         - id
         - name
         - label
+    Cas2Demand:
+      type: object
+      properties:
+        id:
+          type: string
+          format: uuid
+        identifier:
+          type: string
+          example: 'hashed-string'
+          description: 'The unique identifier for the defendant'
+      required:
+        - identifier
     Cas2AssessmentStatusUpdate:
       type: object
       properties:

--- a/src/main/resources/static/codegen/built-cas3-api-spec.yml
+++ b/src/main/resources/static/codegen/built-cas3-api-spec.yml
@@ -2129,8 +2129,27 @@ components:
           type: string
           example: 'hashed-string'
           description: 'The unique identifier for the defendant'
+        createdAt:
+          type: string
+          format: date-time
+        decidedAt:
+          type: string
+          format: date-time
+        locationType:
+          type: string
+          example: 'court'
+        location:
+          type: string
+        primaryReason:
+          type: string
+          example: ""
+        secondaryReason:
+          type: string
       required:
         - identifier
+        - locationType
+        - location
+        - primaryReason
     Cas2AssessmentStatusUpdate:
       type: object
       properties:

--- a/src/main/resources/static/codegen/built-cas3-api-spec.yml
+++ b/src/main/resources/static/codegen/built-cas3-api-spec.yml
@@ -5035,6 +5035,7 @@ components:
         - submitted-applications
         - application-status-updates
         - unsubmitted-applications
+        - bail-demand
     NamedId:
       type: object
       description: A generic stub for an object with a name and an ID.

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/factory/Cas2DemandEntityFactory.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/factory/Cas2DemandEntityFactory.kt
@@ -1,0 +1,55 @@
+package uk.gov.justice.digital.hmpps.approvedpremisesapi.factory
+
+import io.github.bluegroundltd.kfactory.Factory
+import io.github.bluegroundltd.kfactory.Yielded
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.*
+import java.time.OffsetDateTime
+import java.util.UUID
+
+class Cas2DemandEntityFactory : Factory<Cas2DemandEntity> {
+
+  private var id: Yielded<UUID> = { UUID.randomUUID() }
+  private var identifier: Yielded<String> = { UUID.randomUUID().toString() }
+  private var locationType: Yielded<String> = { "" }
+  private var location: Yielded<String> = { "" }
+  private var primaryReason: Yielded<String?> = { "Primary Reason" }
+  private var secondaryReason: Yielded<String?> = { null }
+  private var createdAt: Yielded<OffsetDateTime?> = { OffsetDateTime.now() }
+  private var decidedAt: Yielded<OffsetDateTime?> = { OffsetDateTime.now() }
+
+  fun withIdentifier(identifier: String) = apply {
+    this.identifier = { identifier }
+  }
+
+  fun withLocationAndType(location: String, locationType: String) = apply {
+    this.location = { location }
+    this.locationType = { locationType }
+  }
+
+  fun withPrimaryReason(primaryReason: String) = apply {
+    this.primaryReason = { primaryReason }
+  }
+
+  fun withSecondaryReason(secondaryReason: String) = apply {
+    this.secondaryReason = { secondaryReason }
+  }
+
+  fun withCreatedAt(createdAt: OffsetDateTime) = apply {
+    this.createdAt = { createdAt }
+  }
+
+  fun withDecidedAt(decidedAt: OffsetDateTime) = apply {
+    this.decidedAt = { decidedAt }
+  }
+
+  override fun produce(): Cas2DemandEntity = Cas2DemandEntity(
+    id = this.id(),
+    identifier = this.identifier(),
+    location = this.location(),
+    locationType = this.locationType(),
+    decidedAt = this.decidedAt()!!,
+    createdAt = this.createdAt()!!,
+    primaryReason = this.primaryReason()!!,
+    secondaryReason = this.secondaryReason(),
+  )
+}

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/IntegrationTestBase.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/IntegrationTestBase.kt
@@ -30,76 +30,7 @@ import org.springframework.test.context.ContextConfiguration
 import org.springframework.test.web.reactive.server.WebTestClient
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.client.PrisonsApiClient
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.config.NotifyConfig
-import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.ApAreaEntityFactory
-import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.AppealEntityFactory
-import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.ApplicationTeamCodeEntityFactory
-import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.ApplicationTimelineNoteEntityFactory
-import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.ApprovedPremisesApplicationEntityFactory
-import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.ApprovedPremisesApplicationJsonSchemaEntityFactory
-import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.ApprovedPremisesAssessmentEntityFactory
-import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.ApprovedPremisesAssessmentJsonSchemaEntityFactory
-import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.ApprovedPremisesEntityFactory
-import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.ApprovedPremisesPlacementApplicationJsonSchemaEntityFactory
-import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.ArrivalEntityFactory
-import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.AssessmentClarificationNoteEntityFactory
-import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.AssessmentReferralHistorySystemNoteEntityFactory
-import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.AssessmentReferralHistoryUserNoteEntityFactory
-import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.BedEntityFactory
-import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.BedMoveEntityFactory
-import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.BookingEntityFactory
-import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.BookingNotMadeEntityFactory
-import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.CancellationEntityFactory
-import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.CancellationReasonEntityFactory
-import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.Cas1ApplicationUserDetailsEntityFactory
-import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.Cas1OutOfServiceBedCancellationEntityFactory
-import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.Cas1OutOfServiceBedEntityFactory
-import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.Cas1OutOfServiceBedReasonEntityFactory
-import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.Cas1OutOfServiceBedRevisionEntityFactory
-import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.Cas1SpaceBookingEntityFactory
-import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.Cas2ApplicationEntityFactory
-import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.Cas2ApplicationJsonSchemaEntityFactory
-import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.Cas2AssessmentEntityFactory
-import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.Cas2NoteEntityFactory
-import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.Cas2StatusUpdateDetailEntityFactory
-import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.Cas2StatusUpdateEntityFactory
-import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.CharacteristicEntityFactory
-import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.ConfirmationEntityFactory
-import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.DateChangeEntityFactory
-import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.DepartureEntityFactory
-import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.DepartureReasonEntityFactory
-import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.DestinationProviderEntityFactory
-import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.DomainEventEntityFactory
-import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.ExtensionEntityFactory
-import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.ExternalUserEntityFactory
-import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.LocalAuthorityEntityFactory
-import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.LostBedCancellationEntityFactory
-import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.LostBedReasonEntityFactory
-import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.LostBedsEntityFactory
-import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.MoveOnCategoryEntityFactory
-import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.NomisUserEntityFactory
-import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.NonArrivalEntityFactory
-import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.NonArrivalReasonEntityFactory
-import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.OfflineApplicationEntityFactory
-import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.PersistedFactory
-import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.PlacementApplicationEntityFactory
-import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.PlacementDateEntityFactory
-import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.PlacementRequestEntityFactory
-import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.PlacementRequirementsEntityFactory
-import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.PostCodeDistrictEntityFactory
-import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.ProbationAreaProbationRegionMappingEntityFactory
-import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.ProbationDeliveryUnitEntityFactory
-import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.ProbationRegionEntityFactory
-import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.ReferralRejectionReasonEntityFactory
-import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.RoomEntityFactory
-import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.TemporaryAccommodationApplicationEntityFactory
-import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.TemporaryAccommodationApplicationJsonSchemaEntityFactory
-import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.TemporaryAccommodationAssessmentEntityFactory
-import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.TemporaryAccommodationAssessmentJsonSchemaEntityFactory
-import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.TemporaryAccommodationPremisesEntityFactory
-import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.TurnaroundEntityFactory
-import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.UserEntityFactory
-import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.UserQualificationAssignmentEntityFactory
-import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.UserRoleAssignmentEntityFactory
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.*
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.factory.cas1.Cas1CruManagementAreaEntityFactory
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.integration.asserter.DomainEventAsserter
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.integration.asserter.EmailNotificationAsserter
@@ -108,93 +39,7 @@ import uk.gov.justice.digital.hmpps.approvedpremisesapi.integration.config.TestP
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.integration.mocks.MockFeatureFlagService
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.integration.mocks.MutableClockConfiguration
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.integration.mocks.NoOpSentryService
-import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.ApAreaEntity
-import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.AppealEntity
-import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.ApplicationTeamCodeEntity
-import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.ApplicationTimelineNoteEntity
-import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.ApplicationTimelineNoteRepository
-import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.ApprovedPremisesApplicationEntity
-import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.ApprovedPremisesApplicationJsonSchemaEntity
-import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.ApprovedPremisesAssessmentEntity
-import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.ApprovedPremisesAssessmentJsonSchemaEntity
-import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.ApprovedPremisesEntity
-import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.ApprovedPremisesPlacementApplicationJsonSchemaEntity
-import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.ArrivalEntity
-import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.AssessmentClarificationNoteEntity
-import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.AssessmentReferralHistorySystemNoteEntity
-import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.AssessmentReferralHistoryUserNoteEntity
-import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.BedEntity
-import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.BedMoveEntity
-import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.BedMoveRepository
-import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.BedRepository
-import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.BookingEntity
-import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.BookingNotMadeEntity
-import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.CancellationEntity
-import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.CancellationReasonEntity
-import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.Cas1ApplicationUserDetailsEntity
-import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.Cas1ApplicationUserDetailsRepository
-import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.Cas1CruManagementAreaEntity
-import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.Cas1CruManagementAreaRepository
-import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.Cas1OutOfServiceBedCancellationEntity
-import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.Cas1OutOfServiceBedEntity
-import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.Cas1OutOfServiceBedReasonEntity
-import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.Cas1OutOfServiceBedRevisionEntity
-import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.Cas1SpaceBookingEntity
-import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.Cas1SpaceBookingRepository
-import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.Cas2ApplicationEntity
-import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.Cas2ApplicationJsonSchemaEntity
-import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.Cas2ApplicationNoteEntity
-import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.Cas2ApplicationNoteRepository
-import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.Cas2AssessmentEntity
-import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.Cas2AssessmentRepository
-import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.Cas2StatusUpdateDetailEntity
-import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.Cas2StatusUpdateDetailRepository
-import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.Cas2StatusUpdateEntity
-import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.CharacteristicEntity
-import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.CharacteristicRepository
-import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.ConfirmationEntity
-import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.DateChangeEntity
-import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.DateChangeRepository
-import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.DepartureEntity
-import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.DepartureReasonEntity
-import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.DestinationProviderEntity
-import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.DomainEventEntity
-import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.ExtensionEntity
-import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.ExternalUserEntity
-import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.LocalAuthorityAreaEntity
-import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.LostBedCancellationEntity
-import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.LostBedReasonEntity
-import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.LostBedsEntity
-import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.MoveOnCategoryEntity
-import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.NomisUserEntity
-import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.NonArrivalEntity
-import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.NonArrivalReasonEntity
-import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.OfflineApplicationEntity
-import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.PlacementApplicationEntity
-import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.PlacementApplicationRepository
-import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.PlacementDateEntity
-import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.PlacementDateRepository
-import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.PlacementRequestEntity
-import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.PlacementRequestRepository
-import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.PlacementRequirementsEntity
-import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.PlacementRequirementsRepository
-import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.PostCodeDistrictEntity
-import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.ProbationAreaProbationRegionMappingEntity
-import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.ProbationDeliveryUnitEntity
-import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.ProbationRegionEntity
-import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.ReferralRejectionReasonEntity
-import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.ReferralRejectionReasonRepository
-import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.RoomEntity
-import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.RoomRepository
-import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.TemporaryAccommodationApplicationEntity
-import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.TemporaryAccommodationApplicationJsonSchemaEntity
-import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.TemporaryAccommodationAssessmentEntity
-import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.TemporaryAccommodationAssessmentJsonSchemaEntity
-import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.TemporaryAccommodationPremisesEntity
-import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.TurnaroundEntity
-import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.UserEntity
-import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.UserQualificationAssignmentEntity
-import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.UserRoleAssignmentEntity
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.jpa.entity.*
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.model.deliuscontext.StaffMember
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.model.deliuscontext.StaffMembersPage
 import uk.gov.justice.digital.hmpps.approvedpremisesapi.model.hmppsauth.GetTokenResponse
@@ -267,6 +112,9 @@ import java.util.UUID
 @ActiveProfiles("test")
 @Tag("integration")
 abstract class IntegrationTestBase {
+  @Autowired
+  private lateinit var cas2DemandRepository: Cas2DemandRepository
+
   @Autowired
   lateinit var cas1SpaceBookingRepository: Cas1SpaceBookingRepository
 
@@ -567,6 +415,7 @@ abstract class IntegrationTestBase {
   lateinit var approvedPremisesApplicationEntityFactory: PersistedFactory<ApprovedPremisesApplicationEntity, UUID, ApprovedPremisesApplicationEntityFactory>
   lateinit var cas2ApplicationEntityFactory: PersistedFactory<Cas2ApplicationEntity, UUID, Cas2ApplicationEntityFactory>
   lateinit var cas2AssessmentEntityFactory: PersistedFactory<Cas2AssessmentEntity, UUID, Cas2AssessmentEntityFactory>
+  lateinit var cas2DemandEntityFactory: PersistedFactory<Cas2DemandEntity, UUID, Cas2DemandEntityFactory>
   lateinit var cas2StatusUpdateEntityFactory: PersistedFactory<Cas2StatusUpdateEntity, UUID, Cas2StatusUpdateEntityFactory>
   lateinit var cas2StatusUpdateDetailEntityFactory: PersistedFactory<Cas2StatusUpdateDetailEntity, UUID, Cas2StatusUpdateDetailEntityFactory>
   lateinit var cas2NoteEntityFactory: PersistedFactory<Cas2ApplicationNoteEntity, UUID, Cas2NoteEntityFactory>
@@ -678,6 +527,7 @@ abstract class IntegrationTestBase {
     approvedPremisesApplicationEntityFactory = PersistedFactory({ ApprovedPremisesApplicationEntityFactory() }, approvedPremisesApplicationRepository)
     cas2ApplicationEntityFactory = PersistedFactory({ Cas2ApplicationEntityFactory() }, cas2ApplicationRepository)
     cas2AssessmentEntityFactory = PersistedFactory({ Cas2AssessmentEntityFactory() }, cas2AssessmentRepository)
+    cas2DemandEntityFactory = PersistedFactory({Cas2DemandEntityFactory()}, cas2DemandRepository)
     cas2StatusUpdateEntityFactory = PersistedFactory({ Cas2StatusUpdateEntityFactory() }, cas2StatusUpdateRepository)
     cas2StatusUpdateDetailEntityFactory = PersistedFactory({ Cas2StatusUpdateDetailEntityFactory() }, cas2StatusUpdateDetailRepository)
     cas2NoteEntityFactory = PersistedFactory({ Cas2NoteEntityFactory() }, cas2NoteRepository)

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/cas2/Cas2DemandTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/cas2/Cas2DemandTest.kt
@@ -140,7 +140,7 @@ class Cas2DemandTest : IntegrationTestBase() {
 
       val nullUUID = "00000000-0000-0000-0000-000000000000"
 
-      val returnedDemand = webTestClient.get()
+      webTestClient.get()
         .uri("/cas2/demand/${nullUUID}")
         .header("Authorization", "Bearer $jwt")
         .exchange()

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/cas2/Cas2DemandTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/cas2/Cas2DemandTest.kt
@@ -43,7 +43,10 @@ class Cas2DemandTest : IntegrationTestBase() {
         .header("Authorization", "Bearer $jwt")
         .bodyValue(
           Cas2Demand(
-            identifier = "1"
+            identifier = "1",
+            location = "C1",
+            locationType = "court",
+            primaryReason = "Just because",
           ),
         )
         .exchange()
@@ -64,7 +67,10 @@ class Cas2DemandTest : IntegrationTestBase() {
         .header("Authorization", "Bearer $jwt")
         .bodyValue(
           Cas2Demand(
-            identifier = "1"
+            identifier = "1",
+            location = "C1",
+            locationType = "court",
+            primaryReason = "Just because",
           ),
         )
         .exchange()
@@ -88,7 +94,10 @@ class Cas2DemandTest : IntegrationTestBase() {
         .header("Authorization", "Bearer $jwt")
         .bodyValue(
           Cas2Demand(
-            identifier = "1"
+            identifier = "1",
+            location = "C1",
+            locationType = "court",
+            primaryReason = "Just because",
           ),
         )
         .exchange()

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/cas2/Cas2DemandTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/integration/cas2/Cas2DemandTest.kt
@@ -1,0 +1,142 @@
+package uk.gov.justice.digital.hmpps.approvedpremisesapi.integration.cas2
+
+import org.assertj.core.api.Assertions
+import org.junit.jupiter.api.Nested
+import org.junit.jupiter.api.Test
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.api.model.Cas2Demand
+import uk.gov.justice.digital.hmpps.approvedpremisesapi.integration.IntegrationTestBase
+
+
+class Cas2DemandTest : IntegrationTestBase() {
+
+  @Nested
+  inner class ControlsOnExternalUsers {
+    @Test
+    fun `accessing demand endpoint is forbidden`() {
+      val jwt = jwtAuthHelper.createClientCredentialsJwt(
+        username = "username",
+        authSource = "auth",
+        roles = listOf("ROLE_CAS2_ASSESSOR"),
+      )
+
+      webTestClient.get()
+        .uri("/cas2/demand")
+        .header("Authorization", "Bearer $jwt")
+        .exchange()
+        .expectStatus()
+        .isForbidden
+    }
+  }
+
+  @Nested
+  inner class ControlsOnInternalUsers {
+    @Test
+    fun `submitting demand is not allowed for assessor`() {
+      val jwt = jwtAuthHelper.createClientCredentialsJwt(
+        username = "username",
+        authSource = "nomis",
+        roles = listOf("ROLE_CAS2_ASSESSOR"),
+      )
+
+      webTestClient.post()
+        .uri("/cas2/demand")
+        .header("Authorization", "Bearer $jwt")
+        .bodyValue(
+          Cas2Demand(
+            identifier = "1"
+          ),
+        )
+        .exchange()
+        .expectStatus()
+        .isForbidden
+    }
+
+    @Test
+    fun `submitting demand is allowed for POM`() {
+      val jwt = jwtAuthHelper.createClientCredentialsJwt(
+        username = "username",
+        authSource = "nomis",
+        roles = listOf("ROLE_POM"),
+      )
+
+      webTestClient.post()
+        .uri("/cas2/demand")
+        .header("Authorization", "Bearer $jwt")
+        .bodyValue(
+          Cas2Demand(
+            identifier = "1"
+          ),
+        )
+        .exchange()
+        .expectStatus()
+        .isCreated
+    }
+  }
+
+  @Nested
+  inner class SubmitDemand {
+    @Test
+    fun `submitting a demand works and shows what was saved`() {
+      val jwt = jwtAuthHelper.createClientCredentialsJwt(
+        username = "username",
+        authSource = "nomis",
+        roles = listOf("ROLE_POM"),
+      )
+
+      val returnedDemand = webTestClient.post()
+        .uri("/cas2/demand")
+        .header("Authorization", "Bearer $jwt")
+        .bodyValue(
+          Cas2Demand(
+            identifier = "1"
+          ),
+        )
+        .exchange()
+        .expectStatus()
+        .isCreated
+        .returnResult(Cas2Demand::class.java)
+        .responseBody
+        .blockFirst()
+
+      Assertions.assertThat(returnedDemand).matches {
+        it.identifier == "1"
+      }
+
+      val retrievedDemand = webTestClient.get()
+        .uri("/cas2/demand/${returnedDemand?.id}")
+        .header("Authorization", "Bearer $jwt")
+        .exchange()
+        .expectStatus()
+        .isOk
+        .returnResult(Cas2Demand::class.java)
+        .responseBody
+        .blockFirst()
+
+      Assertions.assertThat(retrievedDemand).matches {
+        it.identifier == "1"
+      }
+
+    }
+  }
+
+  @Nested
+  inner class GetDemand {
+    @Test
+    fun `getting a non-existent demand gives 404`() {
+      val jwt = jwtAuthHelper.createClientCredentialsJwt(
+        username = "username",
+        authSource = "nomis",
+        roles = listOf("ROLE_POM"),
+      )
+
+      val nullUUID = "00000000-0000-0000-0000-000000000000"
+
+      val returnedDemand = webTestClient.get()
+        .uri("/cas2/demand/${nullUUID}")
+        .header("Authorization", "Bearer $jwt")
+        .exchange()
+        .expectStatus()
+        .isNotFound
+    }
+  }
+}


### PR DESCRIPTION
The new endpoint (/cas2/demand) accepts POST requests containing the body of the demand as JSON.  If the user is of the appropriate role, then the data is saved and made available at another endpoint (/cas2/demand/{id}) which will return the entity from the database.

The recorded entity initially looks like the following

```kotlin
  val id: UUID 
  val locationType: String,
  val location: String,
  val primaryReason: String,
  val secondaryReason: String?,
  val createdAt: OffsetDateTime,
  val decidedAt: OffsetDateTime,
```

which is delivered as a CSV when the user visits /cas2/reports/bail-demand
